### PR TITLE
Move context menu items into own group

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
         {
           "when": "editorTextFocus",
           "command": "extension.gotoOnlineLink",
-          "group": "navigation"
+          "group": "GitLink@1"
         },
         {
           "when": "editorTextFocus",
           "command": "extension.copyOnlineLink",
-          "group": "navigation"
+          "group": "GitLink@2"
         }
       ]
     },


### PR DESCRIPTION
Move "Goto Online Link" and "Copy Online Link" from navigation group
into their own group in the editor context menu. With this change
context menu items won't be sorted to the top/beginning of the menu
anymore. Instead they get their own little group.

<img width="677" alt="Screenshot 2019-06-23 at 18 48 38" src="https://user-images.githubusercontent.com/536464/59979393-a7666380-95e7-11e9-8a5d-71f1e6da2e60.png">
