### PR TITLE
Add launch config and fix npm warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 out/
 node_modules/
 .vscode-test/
-package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 out/
 node_modules/
-.vscode/
 .vscode-test/
+package-lock.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceRoot}"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ]
+        }
+    ]
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
+.vscode/**
 .vscode-test/**
 out/test/**
 test/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,3 @@
-.vscode/**
 .vscode-test/**
 out/test/**
 test/**

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Goto/Copy current file's online link, supports multiple remote sources in GitHub/GitLab/BitBucket/VSTS/DevOps",
   "version": "0.5.1",
   "publisher": "qezhu",
+  "license": "MIT",
   "author": {
     "name": "Qinen Zhu",
     "email": "qezhu@outlook.com"


### PR DESCRIPTION
This PR does not add any user-visible features. It just adds

- a `launch.json` to easily test the extension during development
- add `"licence"` to `package.json` to silence a complaint from npm